### PR TITLE
Added Bundle.id

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,7 +2,7 @@
   "object": {
     "pins": [
       {
-        "package": "Swift-Range-Tools",
+        "package": "RangeTools",
         "repositoryURL": "https://github.com/RougeWare/Swift-Range-Tools.git",
         "state": {
           "branch": null,
@@ -11,7 +11,7 @@
         }
       },
       {
-        "package": "Swift-Safe-Collection-Access",
+        "package": "SafeCollectionAccess",
         "repositoryURL": "https://github.com/RougeWare/Swift-Safe-Collection-Access.git",
         "state": {
           "branch": null,
@@ -20,16 +20,16 @@
         }
       },
       {
-        "package": "Swift-SemVer",
+        "package": "SemVer",
         "repositoryURL": "https://github.com/RougeWare/Swift-SemVer.git",
         "state": {
           "branch": null,
-          "revision": "087d41c30c38237179e70178ce93895cd7ff0886",
-          "version": "2.0.0"
+          "revision": "adcdc0836253c9bbb5b337eaa9d87553012ae248",
+          "version": "3.0.0-Beta.5"
         }
       },
       {
-        "package": "Swift-Special-String",
+        "package": "SpecialString",
         "repositoryURL": "https://github.com/RougeWare/Swift-Special-String.git",
         "state": {
           "branch": null,
@@ -38,7 +38,7 @@
         }
       },
       {
-        "package": "Swift-String-Integer-Access",
+        "package": "StringIntegerAccess",
         "repositoryURL": "https://github.com/RougeWare/Swift-String-Integer-Access.git",
         "state": {
           "branch": null,

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "SemVer", url: "https://github.com/RougeWare/Swift-SemVer.git", from: "2.0.0"),
+        .package(name: "SemVer", url: "https://github.com/RougeWare/Swift-SemVer.git", from: "3.0.0-Beta.5"),
         .package(name: "StringIntegerAccess", url: "https://github.com/RougeWare/Swift-String-Integer-Access.git", from: "2.1.0"),
         .package(name: "SpecialString", url: "https://github.com/RougeWare/Swift-Special-String.git", from: "1.1.3"),
     ],

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This includes some sugar for reading your app bundle:
 ```swift
 import Introspection
 
-Introspection.appName // The name of your app, as read from its bundle info
+Introspection.bundleId   // The ID of the main bundle, as read from its info dictionary (e.g. `com.acme.MyApp`)
+Introspection.appName    // The name of your app, as read from its bundle info
 Introspection.appVersion // The semantic version of your app, as read from its bundle info, parsed into a `SemVer` value
 ```
 
@@ -28,6 +29,7 @@ This package also includes a generic version reader for any bundle:
 ```swift
 import Introspection
 
+Introspection.Bundle.id(of: Bundle(for: SomeClass.self))
 Introspection.Bundle.name(of: Bundle(for: SomeClass.self))
 Introspection.Bundle.version(of: Bundle(for: SomeClass.self))
 ```

--- a/Sources/Introspection/Bundle Reading.swift
+++ b/Sources/Introspection/Bundle Reading.swift
@@ -36,6 +36,57 @@ public extension Introspection.Bundle {
 
 
 
+// MARK: - Bundle ID
+
+public extension Foundation.Bundle {
+    
+    /// Finds and returns the ID this bundle.
+    ///
+    /// This uses the bundle's info dictionary's `CFBundleIdentifier` entry as the ID.
+    /// If `CFBundleIdentifier` is missing, the returned value is `"ERROR.NO_BUNDLE_ID_FOUND"`.
+    var id: String {
+        Introspection.Bundle[bundle: self, "CFBundleIdentifier"] ?? "ERROR.NO_BUNDLE_ID_FOUND"
+    }
+}
+
+
+
+public extension Introspection.Bundle {
+    
+    /// Finds and returns the ID the main bundle.
+    ///
+    /// This uses the bundle's info dictionary's `CFBundleIdentifier` entry as the ID.
+    /// If `CFBundleIdentifier` is missing, the returned value is `"ERROR.NO_BUNDLE_ID_FOUND"`.
+    @inline(__always)
+    static var id: String {
+        id(of: .main)
+    }
+    
+    
+    /// Finds and returns the ID the given bundle.
+    ///
+    /// This uses the bundle's info dictionary's `CFBundleIdentifier` entry as the ID.
+    /// If `CFBundleIdentifier` is missing, the returned value is `"ERROR.NO_BUNDLE_ID_FOUND"`.
+    @inline(__always)
+    static func id(of bundle: Foundation.Bundle) -> String {
+        bundle.id
+    }
+}
+
+
+
+public extension Introspection {
+    
+    /// Finds and returns the ID of the main bundle.
+    ///
+    /// This uses the bundle's info dictionary's `CFBundleIdentifier` entry as the ID.
+    /// If `CFBundleIdentifier` is missing, the returned value is `"ERROR.NO_BUNDLE_ID_FOUND"`.
+    @inline(__always)
+    static var bundleId: String { Bundle.id }
+}
+
+
+
 // MARK: - App Version
 
 public extension Foundation.Bundle {
@@ -186,7 +237,7 @@ public extension Introspection.Bundle {
     }
     
     
-    /// Finds and returns the semantic version of the given bundle.
+    /// Finds and returns the name of the given bundle.
     ///
     /// This uses the bundle's info dictionary's `CFBundleName` entry as the name.
     /// If `CFBundleName` is missing, the returned value is an empty string.

--- a/Sources/Introspection/Bundle Reading.swift
+++ b/Sources/Introspection/Bundle Reading.swift
@@ -56,7 +56,11 @@ public extension Foundation.Bundle {
             return .error(title: "BundleInfoDictionaryValueNotFound", details: "CFBundleShortVersionString")
         }
         
-        guard var baseVersion = SemVer(versionString) else {
+        guard
+            var baseVersion = SemVer(versionString)
+                ?? SemVer("\(versionString).0")
+                ?? SemVer("\(versionString).0.0")
+        else {
             return .error(title: "BundleInfoDictionaryValueInvalidFormat", details: "CFBundleShortVersionString")
         }
         
@@ -142,7 +146,8 @@ private extension SemVer {
     ///
     /// - Returns: A semantic version depicting this
     static func error(title: String, details: String...) -> Self {
-        self.init(0, 0, 0, preRelease: .init(identifiers: ["ERROR", title] + details))
+        self.init(0,0,0, preRelease: .init(identifiers: ["ERROR", title] + details))
+            ?? .init(0,0,0)
     }
     
     

--- a/Tests/IntrospectionTests/Bundle Reading tests.swift
+++ b/Tests/IntrospectionTests/Bundle Reading tests.swift
@@ -14,21 +14,61 @@ import SemVer
 
 
 final class BundleReadingTests: XCTestCase {
+    
     func testAppVersion() {
         // I'm not entirely sure how to test this, but I poked through it in the console and it seems to work well
     }
     
     
-    func testSwiftBundleVersion() {
-        XCTAssertEqual(Bundle(path: "/usr/lib/swift")!.version, SemVer(0,0,0, preRelease: ["ERROR", "BundleInfoDictionaryValueNotFound", "CFBundleShortVersionString"]))
-        XCTAssertEqual(Bundle(path: "/usr/lib/swift")!.version.description, "0.0.0-ERROR.BundleInfoDictionaryValueNotFound.CFBundleShortVersionString")
+    func testSwiftBundle() {
+        XCTAssertEqual(Introspection.Bundle.id(of: .swift), "ERROR.NO_BUNDLE_ID_FOUND")
+        
+        XCTAssertEqual(Introspection.Bundle.name(of: .swift), "")
+        
+        XCTAssertEqual(Introspection.Bundle.version(of: .swift), SemVer(0,0,0, preRelease: ["ERROR", "BundleInfoDictionaryValueNotFound", "CFBundleShortVersionString"]))
+        XCTAssertEqual(Introspection.Bundle.version(of: .swift).description, "0.0.0-ERROR.BundleInfoDictionaryValueNotFound.CFBundleShortVersionString")
     }
     
     
-    func testAppName() {
+    func testFinderBundle() {
+        XCTAssertEqual(Introspection.Bundle.id(of: .finder), "com.apple.finder")
+        
+        XCTAssertEqual(Introspection.Bundle.name(of: .finder), "Finder")
+        
+        XCTAssertGreaterThan(Introspection.Bundle.version(of: .finder), SemVer(1,0,0))
+    }
+    
+    
+    func testThisBundle() {
+        
+        // MARK: ID
+        
+        XCTAssertEqual(Introspection.bundleId, "com.apple.dt.xctest.tool")
+        XCTAssertEqual(Introspection.Bundle.id, "com.apple.dt.xctest.tool")
+        XCTAssertEqual(Introspection.Bundle.id(of: .main), "com.apple.dt.xctest.tool")
+        XCTAssertEqual(Bundle.main.id, "com.apple.dt.xctest.tool")
+        
+        
+        // MARK: App Name
+        
         XCTAssertEqual(Introspection.appName, "xctest")
         XCTAssertEqual(Introspection.Bundle.name, "xctest")
         XCTAssertEqual(Introspection.Bundle.name(of: .main), "xctest")
         XCTAssertEqual(Bundle.main.name, "xctest")
+        
+        
+        // MARK: Version
+        
+        XCTAssertGreaterThan(Introspection.appVersion, SemVer(10,0,0))
+        XCTAssertGreaterThan(Introspection.Bundle.version, SemVer(10,0,0))
+        XCTAssertGreaterThan(Introspection.Bundle.version(of: .main), SemVer(10,0,0))
+        XCTAssertGreaterThan(Bundle.main.version, SemVer(10,0,0))
     }
+}
+
+
+
+private extension Bundle {
+    static var swift: Self { Self(path: "/usr/lib/swift")! }
+    static var finder: Self { Self(path: "/System/Library/CoreServices/Finder.app")! }
 }


### PR DESCRIPTION
Added the ability to read the bundle ID with any of these:

```swift
Introspection.Bundle.id
Introspection.Bundle.id(of: .main) // Or any other Foundation.Bundle instance
Introspection.bundleId
Bundle.main.id // Or any other Foundation.Bundle instance
```


### Also: ###

- Also updated SemVer to `3.0.0-Beta.5`
- Also resolved other packages
- Support for iOS device info