### PR TITLE
Support for identifying a generic Mac as the current device

### DIFF
--- a/Sources/Introspection/Device Info.swift
+++ b/Sources/Introspection/Device Info.swift
@@ -146,6 +146,12 @@ public extension Introspection.Device {
 //    }
     
     
+    /// Represents a generic Apple Mac.
+    ///
+    /// For some reason, some newer Mac models report themselves generically as `"Mac"`, rather than specifying what kind.
+    static let mac = Self(modelType: .mac)
+    
+    
     /// Represents Apple's MacBook
     static let macBook = Self(modelType: .macBook)
     

--- a/Sources/Introspection/Device Info.swift
+++ b/Sources/Introspection/Device Info.swift
@@ -203,6 +203,13 @@ public extension Introspection.Device {
 
 public extension Introspection.Device.ModelType {
     
+    /// The model type prefix for Apple's generic Mac.
+    ///
+    /// For some reason, Apple seems to be making some devices just report themselves as just `"Mac"`.
+    /// For example, the 16-inch MacBook Pro (Nov 2024) reports itself as `"Mac16,7"`
+    static let mac: Self = "Mac"
+    
+    
     /// The model type prefix for Apple's MacBook
     static let macBook: Self = "MacBook"
     
@@ -305,7 +312,8 @@ public extension Introspection.Device.ModelType {
         case .iMac, .iMacPro, .macMini, .macPro:
             return .desktop
             
-        case .macBook, .macBookAir, .macBookPro:
+        case .macBook, .macBookAir, .macBookPro,
+                .mac:
             return .laptop
             
         case .iPad:

--- a/Sources/Introspection/Device Info.swift
+++ b/Sources/Introspection/Device Info.swift
@@ -265,6 +265,9 @@ public extension Introspection.Device.ModelType {
     /// The model type prefix for Apple's arm64 iPhone Simulator
     static let iPhoneSimulator_arm64: Self = "arm64"
     
+    /// The model type prefix for a virtualized version of Apple's Mac
+    static let virtualizedMac: Self = "VirtualMac"
+    
     /// The model type prefix for a VMWare virtual machine
     static let vm_vmware: Self = "VMware"
     
@@ -357,7 +360,8 @@ public extension Introspection.Device.ModelType {
     /// Determines whether this model type likely represents a virtual machine
     var isVirtualMachine: Bool {
         switch self {
-        case .vm_vmware:
+        case .vm_vmware,
+                .virtualizedMac:
             return true
             
         default:

--- a/Tests/IntrospectionTests/Device Info tests.swift
+++ b/Tests/IntrospectionTests/Device Info tests.swift
@@ -34,6 +34,8 @@ final class DeviceInfoTests: XCTestCase {
     
     
     func testModelTypeInferredClassAccurate() {
+        XCTAssertEqual(Introspection.Device.mac.deviceClass, .laptop)
+        
         XCTAssertEqual(Introspection.Device.macBook.deviceClass, .laptop)
         XCTAssertEqual(Introspection.Device.macBookAir.deviceClass, .laptop)
         XCTAssertEqual(Introspection.Device.macBookPro.deviceClass, .laptop)


### PR DESCRIPTION
Some modern Mac models don't report which specific type of Mac they are, just `"Mac"`, so this PR adds a model type prefix matching that.