### PR TITLE
Added executableName

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,24 @@
   "object": {
     "pins": [
       {
+        "package": "CollectionTools",
+        "repositoryURL": "https://github.com/RougeWare/Swift-Collection-Tools.git",
+        "state": {
+          "branch": null,
+          "revision": "1918c72a1dabbc3ffb92b7bd3ab84cb565951e50",
+          "version": "3.2.0"
+        }
+      },
+      {
+        "package": "FunctionTools",
+        "repositoryURL": "https://github.com/RougeWare/Swift-Function-Tools",
+        "state": {
+          "branch": null,
+          "revision": "a854f4ed89b7e404019b5a09d24e067acc15432d",
+          "version": "1.2.4"
+        }
+      },
+      {
         "package": "RangeTools",
         "repositoryURL": "https://github.com/RougeWare/Swift-Range-Tools.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
     
     dependencies: [
         // Dependencies declare other packages that this package depends on.
+        .package(name: "CollectionTools", url: "https://github.com/RougeWare/Swift-Collection-Tools.git", from: "3.2.0"),
         .package(name: "SemVer", url: "https://github.com/RougeWare/Swift-SemVer.git", from: "3.0.0-Beta.5"),
         .package(name: "StringIntegerAccess", url: "https://github.com/RougeWare/Swift-String-Integer-Access.git", from: "2.1.0"),
         .package(name: "SpecialString", url: "https://github.com/RougeWare/Swift-Special-String.git", from: "1.1.3"),
@@ -34,6 +35,7 @@ let package = Package(
             name: "Introspection",
             dependencies: [
                 .product(name: "SafeStringIntegerAccess", package: "StringIntegerAccess"),
+                "CollectionTools",
                 "SemVer",
                 "SpecialString",
                 "StringIntegerAccess",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Introspection.appName    // The name of your app, as read from its bundle info
 Introspection.appVersion // The semantic version of your app, as read from its bundle info, parsed into a `SemVer` value
 ```
 
+and generic executable:
+```swift
+Introspection.executableName // What you'd start with on the command line to run this program
+```
+
 
 This package also includes a generic version reader for any bundle:
 

--- a/Sources/Introspection/Bundle Reading.swift
+++ b/Sources/Introspection/Bundle Reading.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+import CollectionTools
 import SemVer
 
 
@@ -218,9 +219,18 @@ public extension Foundation.Bundle {
     /// Finds and returns the name this bundle.
     ///
     /// This uses the bundle's info dictionary's `CFBundleName` entry as the name.
-    /// If `CFBundleName` is missing, the returned value is an empty string.
-    var name: String {
-        infoDictionary?["CFBundleName"] as? String ?? ""
+    /// If `CFBundleName` is missing, `nil` is returned.
+    var name: String? {
+        infoDictionary?["CFBundleName"] as? String
+    }
+    
+    
+    /// Finds and returns the name of the executable inside this bundle.
+    ///
+    /// This uses the bundle's info dictionary's `CFBundleExecutable` entry as the executable name.
+    /// If `CFBundleExecutable` is missing, `nil` is returned.
+    var executableName: String? {
+        infoDictionary?["CFBundleExecutable"] as? String
     }
 }
 
@@ -231,8 +241,8 @@ public extension Introspection.Bundle {
     /// Finds and returns the name of the application bundle.
     ///
     /// This uses the bundle's info dictionary's `CFBundleName` entry as the name.
-    /// If `CFBundleName` is missing, the returned value is an empty string.
-    static var name: String {
+    /// If `CFBundleName` is missing, `nil` is returned.
+    static var name: String? {
         name(of: .main)
     }
     
@@ -240,10 +250,29 @@ public extension Introspection.Bundle {
     /// Finds and returns the name of the given bundle.
     ///
     /// This uses the bundle's info dictionary's `CFBundleName` entry as the name.
-    /// If `CFBundleName` is missing, the returned value is an empty string.
+    /// If `CFBundleName` is missing, `nil` is returned.
     @inline(__always)
-    static func name(of bundle: Foundation.Bundle) -> String {
+    static func name(of bundle: Foundation.Bundle) -> String? {
         bundle.name
+    }
+    
+    
+    /// Finds and returns the name of the application bundle.
+    ///
+    /// This uses the bundle's info dictionary's `CFBundleExecutable` entry as the name.
+    /// If `CFBundleExecutable` is missing, `nil` is returned.
+    static var executableName: String? {
+        executableName(of: .main)
+    }
+    
+    
+    /// Finds and returns the name of the given bundle.
+    ///
+    /// This uses the bundle's info dictionary's `CFBundleExecutable` entry as the name.
+    /// If `CFBundleExecutable` is missing, `nil` is returned.
+    @inline(__always)
+    static func executableName(of bundle: Foundation.Bundle) -> String? {
+        bundle.executableName
     }
 }
 
@@ -251,12 +280,17 @@ public extension Introspection.Bundle {
 
 public extension Introspection {
     
-    /// Finds and returns the name of the application bundle.
+    /// Finds and returns the name of the application bundle or its contained executable.
     ///
-    /// This uses the bundle's info dictionary's `CFBundleName` entry as the name.
-    /// If `CFBundleName` is missing, the returned value is an empty string.
+    /// This first looks for the bundle's name, but if that isn't found then the executable name is returned (either the bundle's executable or the current process's).
     @inline(__always)
-    static var appName: String { Bundle.name }
+    static var appName: String { Bundle.name?.nonEmptyOrNil ?? Bundle.executableName?.nonEmptyOrNil ?? executableName /*?? "this app (name not found)"*/ }
+    
+    
+    /// Finds and returns the name of the currently-running process's main executable
+    static var executableName: String {
+        ProcessInfo.processInfo.processName
+    }
 }
 
 

--- a/Tests/IntrospectionTests/Bundle Reading tests.swift
+++ b/Tests/IntrospectionTests/Bundle Reading tests.swift
@@ -23,7 +23,8 @@ final class BundleReadingTests: XCTestCase {
     func testSwiftBundle() {
         XCTAssertEqual(Introspection.Bundle.id(of: .swift), "ERROR.NO_BUNDLE_ID_FOUND")
         
-        XCTAssertEqual(Introspection.Bundle.name(of: .swift), "")
+        XCTAssertEqual(Introspection.Bundle.name(of: .swift), nil)
+        XCTAssertEqual(Introspection.Bundle.executableName(of: .swift), nil)
         
         XCTAssertEqual(Introspection.Bundle.version(of: .swift), SemVer(0,0,0, preRelease: ["ERROR", "BundleInfoDictionaryValueNotFound", "CFBundleShortVersionString"]))
         XCTAssertEqual(Introspection.Bundle.version(of: .swift).description, "0.0.0-ERROR.BundleInfoDictionaryValueNotFound.CFBundleShortVersionString")
@@ -55,6 +56,14 @@ final class BundleReadingTests: XCTestCase {
         XCTAssertEqual(Introspection.Bundle.name, "xctest")
         XCTAssertEqual(Introspection.Bundle.name(of: .main), "xctest")
         XCTAssertEqual(Bundle.main.name, "xctest")
+        
+        
+        // MARK: Executable Name
+        
+        XCTAssertEqual(Introspection.executableName, "xctest")
+        XCTAssertEqual(Introspection.Bundle.executableName, "xctest")
+        XCTAssertEqual(Introspection.Bundle.executableName(of: .main), "xctest")
+        XCTAssertEqual(Bundle.main.executableName, "xctest")
         
         
         // MARK: Version


### PR DESCRIPTION
Lookin like a new major version!

This updates the bundle-reading extensions to return String? for name and adds a new `executableName` property, returning `CFBundleExecutable` or the current process name depending on which API the dev calls.

# Breaking changes

The `Introspection.appName` API has been updated to backup to this new `executableName` if no bundle name was found. Along with this, bundle name APIs return `nil` when none is found, rather than an empty string.

This also adds [the CollectionTools package](https://github.com/RougeWare/Swift-Collection-Tools) dependency, used for convenience string handling.